### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/fksnewsfeed.php
+++ b/syntax/fksnewsfeed.php
@@ -53,7 +53,7 @@ class syntax_plugin_fksnewsfeed_fksnewsfeed extends DokuWiki_Syntax_Plugin {
         return array($state,array($param));
     }
 
-    public function render($mode,Doku_Renderer &$renderer,$data) {
+    public function render($mode,Doku_Renderer $renderer,$data) {
         // $data is what the function handle return'ed.
         if($mode == 'xhtml'){
             /** @var Do ku_Renderer_xhtml $renderer */

--- a/syntax/fksnewsfeedstream.php
+++ b/syntax/fksnewsfeedstream.php
@@ -52,7 +52,7 @@ class syntax_plugin_fksnewsfeed_fksnewsfeedstream extends DokuWiki_Syntax_Plugin
         return array($state,array($param));
     }
 
-    public function render($mode,Doku_Renderer &$renderer,$data) {
+    public function render($mode,Doku_Renderer $renderer,$data) {
         if($mode !== 'xhtml'){
             return;
         }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
